### PR TITLE
Fix: hardcoded properties

### DIFF
--- a/GamificationActionService/src/main/java/i5/las2peer/services/gamificationActionService/GamificationActionService.java
+++ b/GamificationActionService/src/main/java/i5/las2peer/services/gamificationActionService/GamificationActionService.java
@@ -124,11 +124,6 @@ public class GamificationActionService extends RESTService {
 		// read and set properties values
 		// IF THE SERVICE CLASS NAME IS CHANGED, THE PROPERTIES FILE NAME NEED TO BE CHANGED TOO!
 		setFieldValues();
-		jdbcDriverClassName="org.postgresql.Driver";
-		jdbcUrl="jdbc:postgresql://gamification-db-service.ba-mbelsch:5432/";
-		jdbcSchema="postgres";
-		jdbcLogin="postgres";
-		jdbcPass="postgres";
 		dbm = new DatabaseManager(jdbcDriverClassName, jdbcLogin, jdbcPass, jdbcUrl, jdbcSchema);
 		this.actionAccess = new ActionDAO();
 	}


### PR DESCRIPTION
**Note**: First merge https://github.com/rwth-acis/Gamification-Framework/pull/20

The properties (e.g., database URL) were hard-coded into the service constructor instead of relying on the `setFieldValues()` method which should set them from the services `.properties` file.